### PR TITLE
Order status completed including spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,7 +12,7 @@ AllCops:
     - bin/**/**
     - node_modules/**/**
 Layout/LineLength:
-  Max: 130
+  Max: 120
 Metrics/ClassLength:
   Max: 200
 Metrics/MethodLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,3 +43,6 @@ RSpec/ContextWording:
   Enabled: false
 Rails/LexicallyScopedActionFilter:
   Enabled: false
+RSpec/RepeatedExampleGroupBody:
+  Exclude: 
+    - 'spec/requests/order_status_request_spec.rb'

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -11,8 +11,7 @@ class Admin::OrdersController < Admin::BaseController
 
   def order_status
     @order = order
-    if state_validation(@order, :state)
-      @order.update(state: params[:state])
+    if @order.update(state: params[:state])
       flash[:notice] = "Status updated to #{@order.state}"
     else
       flash[:alert] = 'Something went wrong.'
@@ -22,8 +21,7 @@ class Admin::OrdersController < Admin::BaseController
 
   def payment_status
     @order = order
-    if state_validation(@order.payment, :aasm_state)
-      @order.payment.update(aasm_state: params[:aasm_state])
+    if @order.payment.update(aasm_state: params[:aasm_state])
       flash[:notice] = "Status updated to #{@order.payment.aasm_state}"
     else
       flash[:alert] = 'Something went wrong.'
@@ -33,8 +31,7 @@ class Admin::OrdersController < Admin::BaseController
 
   def shipment_status
     @order = order
-    if state_validation(@order.shipment, :aasm_state)
-      @order.shipment.update(aasm_state: params[:aasm_state])
+    if @order.shipment.update(aasm_state: params[:aasm_state])
       flash[:notice] = "Status updated to #{@order.shipment.aasm_state}"
     else
       flash[:alert] = 'Something went wrong.'
@@ -46,9 +43,5 @@ class Admin::OrdersController < Admin::BaseController
 
   def order
     Order.find(params[:id])
-  end
-
-  def state_validation(obj, state)
-    obj.aasm.states.map(&:name).include?(params[state].to_sym)
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -15,8 +15,8 @@ class Admin::OrdersController < Admin::BaseController
       flash[:notice] = "Status updated to #{@order.state}"
       render 'show'
     else
-      flash[:alert] = "Something went wrong."
-      render 'show'
+      flash[:alert] = 'Something went wrong.'
+      render 'index'
     end
   end
 
@@ -26,8 +26,8 @@ class Admin::OrdersController < Admin::BaseController
       flash[:notice] = "Status updated to #{@order.payment.aasm_state}"
       render 'show'
     else
-      flash[:alert] = "Something went wrong."
-      render 'show'
+      flash[:alert] = 'Something went wrong.'
+      render 'index'
     end
   end
 
@@ -37,8 +37,8 @@ class Admin::OrdersController < Admin::BaseController
       flash[:notice] = "Status updated to #{@order.shipment.aasm_state}"
       render 'show'
     else
-      flash[:alert] = "Something went wrong."
-      render 'show'
+      flash[:alert] = 'Something went wrong.'
+      render 'index'
     end
   end
 

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -11,40 +11,44 @@ class Admin::OrdersController < Admin::BaseController
 
   def order_status
     @order = order
-    if @order.update!(state: params[:state])
+    if state_validation(@order, :state)
+      @order.update(state: params[:state])
       flash[:notice] = "Status updated to #{@order.state}"
-      render 'show'
     else
       flash[:alert] = 'Something went wrong.'
-      render 'index'
     end
+    render 'show'
   end
 
   def payment_status
     @order = order
-    if @order.payment.update!(aasm_state: params[:aasm_state])
+    if state_validation(@order.payment, :aasm_state)
+      @order.payment.update(aasm_state: params[:aasm_state])
       flash[:notice] = "Status updated to #{@order.payment.aasm_state}"
-      render 'show'
     else
       flash[:alert] = 'Something went wrong.'
-      render 'index'
     end
+    render 'show'
   end
 
   def shipment_status
     @order = order
-    if @order.shipment.update!(aasm_state: params[:aasm_state])
+    if state_validation(@order.shipment, :aasm_state)
+      @order.shipment.update(aasm_state: params[:aasm_state])
       flash[:notice] = "Status updated to #{@order.shipment.aasm_state}"
-      render 'show'
     else
       flash[:alert] = 'Something went wrong.'
-      render 'index'
     end
+    render 'show'
   end
 
   private
 
   def order
     Order.find(params[:id])
+  end
+
+  def state_validation(obj, state)
+    obj.aasm.states.map(&:name).include?(params[state].to_sym)
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -11,21 +11,21 @@ class Admin::OrdersController < Admin::BaseController
 
   def order_status
     @order = order
-    @order.update(state: params[:state])
+    @order.update!(state: params[:state])
     flash[:notice] = "Status updated to #{@order.state}"
     render 'show'
   end
 
   def payment_status
     @order = order
-    @order.payment.update(aasm_state: params[:aasm_state])
+    @order.payment.update!(aasm_state: params[:aasm_state])
     flash[:notice] = "Status updated to #{@order.payment.aasm_state}"
     render 'show'
   end
 
   def shipment_status
     @order = order
-    @order.shipment.update(aasm_state: params[:aasm_state])
+    @order.shipment.update!(aasm_state: params[:aasm_state])
     flash[:notice] = "Status updated to #{@order.shipment.aasm_state}"
     render 'show'
   end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -11,23 +11,35 @@ class Admin::OrdersController < Admin::BaseController
 
   def order_status
     @order = order
-    @order.update!(state: params[:state])
-    flash[:notice] = "Status updated to #{@order.state}"
-    render 'show'
+    if @order.update!(state: params[:state])
+      flash[:notice] = "Status updated to #{@order.state}"
+      render 'show'
+    else
+      flash[:alert] = "Something went wrong."
+      render 'show'
+    end
   end
 
   def payment_status
     @order = order
-    @order.payment.update!(aasm_state: params[:aasm_state])
-    flash[:notice] = "Status updated to #{@order.payment.aasm_state}"
-    render 'show'
+    if @order.payment.update!(aasm_state: params[:aasm_state])
+      flash[:notice] = "Status updated to #{@order.payment.aasm_state}"
+      render 'show'
+    else
+      flash[:alert] = "Something went wrong."
+      render 'show'
+    end
   end
 
   def shipment_status
     @order = order
-    @order.shipment.update!(aasm_state: params[:aasm_state])
-    flash[:notice] = "Status updated to #{@order.shipment.aasm_state}"
-    render 'show'
+    if @order.shipment.update!(aasm_state: params[:aasm_state])
+      flash[:notice] = "Status updated to #{@order.shipment.aasm_state}"
+      render 'show'
+    else
+      flash[:alert] = "Something went wrong."
+      render 'show'
+    end
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -15,7 +15,7 @@ class Order < ApplicationRecord
     state :failed, :completed
 
     event :done do
-      transitions from: :new, to: :completed
+      transitions from: :new, to: :completed, guard: :paid_and_shipped?
     end
 
     event :undone do
@@ -43,5 +43,9 @@ class Order < ApplicationRecord
 
   def ship_transitions
     shipment.aasm.permitted_transitions
+  end
+
+  def paid_and_shipped?
+    payment.completed? && shipment.shipped?
   end
 end

--- a/app/services/checkout_services.rb
+++ b/app/services/checkout_services.rb
@@ -15,7 +15,8 @@ module CheckoutServices
     def checkout(cart, user)
       ActiveRecord::Base.transaction do
         @payment = Payment.create!
-        @order = Order.create!(user_id: user.id, payment_id: @payment.id)
+        @shipment = Shipment.create!
+        @order = Order.create!(user_id: user.id, payment_id: @payment.id, shipment_id: @shipment.id)
         cart.line_items.each do |line_item|
           line_item.update!(cart_id: nil, order_id: @order.id)
         end

--- a/app/views/products/index.html.erb
+++ b/app/views/products/index.html.erb
@@ -6,7 +6,11 @@
   <% @products.each do |product| %>
   <div class="col-lg-4 col-md-6 mb-4">
     <div class="card h-100">
-      <%= image_tag product.cover_photo, :size => '250x260' %>
+       <% if product.cover_photo.attached? %>
+        <%= image_tag product.cover_photo, :size => '250x260' %>
+      <% else %>
+        <a href="#"><img class="card-img-top product-card-placeholder-img" src="https://via.placeholder.com/150" alt=""></a>
+      <% end %>
       <div class="card-body">
         <h4 class="card-title">
           <a href="#"><%= link_to product.name, product_path(product) %></a>

--- a/spec/requests/order_status_request_spec.rb
+++ b/spec/requests/order_status_request_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
     end
 
     context "when shipment status is 'shipped' and payment status is 'completed'" do
-      it "admin is allowed to change order status to 'completed'" do
+      it "is allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=shipped"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
@@ -42,7 +42,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
     end
 
     context "when shipment status isn't 'shipped' and payment status isn't 'completed'" do
-      it "admin is not allowed to change order status to 'completed'" do
+      it "is not allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=pending"
         order.reload
@@ -51,7 +51,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
     end
 
     context "when shipment status isn't 'shipped' and payment status is 'completed'" do
-      it "admin is not allowed to change order status to 'completed'" do
+      it "is not allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
         order.reload
@@ -60,7 +60,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
     end
 
     context "when shipment status is 'shipped' and payment status isn't 'completed'" do
-      it "admin is not allowed to change order status to 'completed'" do
+      it "is not allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
         order.reload
@@ -70,7 +70,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
   end
 
   describe 'when logged in as user' do
-    it 'user is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       post user_session_path, params: { user: { email: user.email, password: user.password } }
       get '/admin/orders'
       expect(response).to have_http_status(:found)
@@ -79,7 +79,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
   end
 
   describe 'when guest visits app' do
-    it 'guest is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       get "/admin/orders/#{order.id}"
       expect(response).to have_http_status(:found)
       expect(response).to redirect_to '/'

--- a/spec/requests/order_status_request_spec.rb
+++ b/spec/requests/order_status_request_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
 
   describe 'when logged in as admin' do
     let(:admin) { create(:admin) }
+
     before do
       post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
@@ -24,27 +25,27 @@ RSpec.describe 'AdminOrderStatus', type: :request do
       it "change an order's status from 'new' to 'failed'" do
         patch "/admin/orders/#{order.id}/order_status?state=failed"
         expect(response).to have_http_status(:ok)
-        order.reload 
+        order.reload
         expect(order).to have_state(:failed)
       end
     end
-  
+
     context "when shipment status is 'shipped' and payment status is 'completed'" do
       it "admin is allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=shipped"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
         patch "/admin/orders/#{order.id}/order_status?state=completed"
-        order.reload 
+        order.reload
         expect(order).to have_state(:completed)
       end
     end
-  
+
     context "when shipment status isn't 'shipped' and payment status isn't 'completed'" do
       it "admin is not allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=pending"
-        order.reload 
+        order.reload
         expect(order).not_to allow_event :done
       end
     end
@@ -53,7 +54,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
       it "admin is not allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
-        order.reload 
+        order.reload
         expect(order).not_to allow_event :done
       end
     end
@@ -62,7 +63,7 @@ RSpec.describe 'AdminOrderStatus', type: :request do
       it "admin is not allowed to change order status to 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
-        order.reload 
+        order.reload
         expect(order).not_to allow_event :done
       end
     end

--- a/spec/requests/order_status_request_spec.rb
+++ b/spec/requests/order_status_request_spec.rb
@@ -3,51 +3,67 @@
 require 'rails_helper'
 
 RSpec.describe 'AdminOrderStatus', type: :request do
-  let(:admin) { create(:admin) }
   let(:user) { create(:user) }
   let(:shipment) { create(:shipment) }
   let(:payment) { create(:payment) }
-  let!(:order) { create(:order, user_id: user.id, payment_id: payment.id, shipment_id: shipment.id) }
+  let(:order) { create(:order, user: user, payment: payment, shipment: shipment) }
 
   describe 'when logged in as admin' do
+    let(:admin) { create(:admin) }
     before do
       post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
 
-    context 'you are allowed to'
-    it "gets order's page with order's status" do
-      get "/admin/orders/#{Order.last.id}"
-      expect(response).to have_http_status(:ok)
-      expect(order).to have_state(:new)
-    end
+    context 'you are allowed to' do
+      it "gets order's page with order's status" do
+        get "/admin/orders/#{order.id}"
+        expect(response).to have_http_status(:ok)
+        expect(order).to have_state(:new)
+      end
 
-    it "change an order's status from 'new' to 'failed'" do
-      patch "/admin/orders/#{Order.last.id}/order_status?state=failed"
-      expect(response).to have_http_status(:ok)
-      expect(Order.last).to have_state(:failed)
+      it "change an order's status from 'new' to 'failed'" do
+        patch "/admin/orders/#{order.id}/order_status?state=failed"
+        expect(response).to have_http_status(:ok)
+        order.reload 
+        expect(order).to have_state(:failed)
+      end
     end
-
-    context "you have permission to change order status to 'completed' only if" do
-      it "shipment status is 'shipped' and payment status is 'completed'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=shipped"
-        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
-        patch "/admin/orders/#{Order.last.id}/order_status?state=completed"
-        expect(Order.last).to have_state(:completed)
+  
+    context "when shipment status is 'shipped' and payment status is 'completed'" do
+      it "admin is allowed to change order status to 'completed'" do
+        patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{order.id}/shipment_status?aasm_state=shipped"
+        patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
+        patch "/admin/orders/#{order.id}/order_status?state=completed"
+        order.reload 
+        expect(order).to have_state(:completed)
+      end
+    end
+  
+    context "when shipment status isn't 'shipped' and payment status isn't 'completed'" do
+      it "admin is not allowed to change order status to 'completed'" do
+        patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{order.id}/payment_status?aasm_state=pending"
+        order.reload 
+        expect(order).not_to allow_event :done
       end
     end
 
-    context "you don't have permission to change order status to 'completed' if" do
-      it "shipment status isn't 'shipped' and payment status isn't 'completed'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=pending"
-        expect(Order.last).not_to allow_event :done
+    context "when shipment status isn't 'shipped' and payment status is 'completed'" do
+      it "admin is not allowed to change order status to 'completed'" do
+        patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
+        order.reload 
+        expect(order).not_to allow_event :done
       end
+    end
 
-      it "shipment status isn't 'shipped' and payment status is 'completed'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
-        expect(Order.last).not_to allow_event :done
+    context "when shipment status is 'shipped' and payment status isn't 'completed'" do
+      it "admin is not allowed to change order status to 'completed'" do
+        patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
+        order.reload 
+        expect(order).not_to allow_event :done
       end
     end
   end
@@ -61,9 +77,9 @@ RSpec.describe 'AdminOrderStatus', type: :request do
     end
   end
 
-  describe 'without logging in' do
-    it 'visitor is not allowed to visit order page' do
-      get "/admin/orders/#{Order.last.id}"
+  describe 'when guest visits app' do
+    it 'guest is not allowed to visit order page' do
+      get "/admin/orders/#{order.id}"
       expect(response).to have_http_status(:found)
       expect(response).to redirect_to '/'
     end

--- a/spec/requests/order_status_request_spec.rb
+++ b/spec/requests/order_status_request_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'AdminOrderStatus', type: :request do
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+  let(:shipment) { create(:shipment) }
+  let(:payment) { create(:payment) }
+  let!(:order) { create(:order, user_id: user.id, payment_id: payment.id, shipment_id: shipment.id) }
+
+  describe 'when logged in as admin' do
+    before do
+      post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
+    end
+
+    context 'you are allowed to'
+    it "gets order's page with order's status" do
+      get "/admin/orders/#{Order.last.id}"
+      expect(response).to have_http_status(:ok)
+      expect(order).to have_state(:new)
+    end
+
+    it "change an order's status from 'new' to 'failed'" do
+      patch "/admin/orders/#{Order.last.id}/order_status?state=failed"
+      expect(response).to have_http_status(:ok)
+      expect(Order.last).to have_state(:failed)
+    end
+
+    context "you have permission to change order status to 'completed' only if" do
+      it "shipment status is 'shipped' and payment status is 'completed'" do
+        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=shipped"
+        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
+        patch "/admin/orders/#{Order.last.id}/order_status?state=completed"
+        expect(Order.last).to have_state(:completed)
+      end
+    end
+
+    context "you don't have permission to change order status to 'completed' if" do
+      it "shipment status isn't 'shipped' and payment status isn't 'completed'" do
+        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=pending"
+        expect(Order.last).not_to allow_event :done
+      end
+
+      it "shipment status isn't 'shipped' and payment status is 'completed'" do
+        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
+        expect(Order.last).not_to allow_event :done
+      end
+    end
+  end
+
+  describe 'when logged in as user' do
+    it 'user is not allowed to visit order page' do
+      post user_session_path, params: { user: { email: user.email, password: user.password } }
+      get '/admin/orders'
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to '/'
+    end
+  end
+
+  describe 'without logging in' do
+    it 'visitor is not allowed to visit order page' do
+      get "/admin/orders/#{Order.last.id}"
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to '/'
+    end
+  end
+end

--- a/spec/requests/payment_status_request_spec.rb
+++ b/spec/requests/payment_status_request_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
 
   context 'when logged in as admin' do
     let(:admin) { create(:admin) }
+
     before do
       post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end

--- a/spec/requests/payment_status_request_spec.rb
+++ b/spec/requests/payment_status_request_spec.rb
@@ -3,51 +3,51 @@
 require 'rails_helper'
 
 RSpec.describe 'AdminOrderPaymentStatus', type: :request do
-  describe 'GET orders#show' do
+  let(:user) { create(:user) }
+  let(:payment) { create(:payment) }
+  let(:order) { create(:order, user: user, payment: payment) }
+
+  context 'when logged in as admin' do
     let(:admin) { create(:admin) }
-    let(:user) { create(:user) }
-    let!(:payment) { create(:payment) }
-    let!(:order) { create(:order, user_id: user.id, payment_id: payment.id) }
-
-    context 'when logged in as admin' do
-      before do
-        post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
-      end
-
-      it "gets order's page with order's payment status" do
-        get "/admin/orders/#{Order.last.id}"
-        expect(response).to have_http_status(:ok)
-        expect(response.body).to include(order.payment.aasm_state.to_s)
-      end
-
-      it "admin can change an order's payment status from 'pending' to 'failed'" do
-        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=failed"
-        expect(response).to have_http_status(:ok)
-        expect(Payment.last).to have_state(:failed)
-      end
-
-      it "admin can change an order's payment status from 'pending' to 'completed'" do
-        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
-        expect(response).to have_http_status(:ok)
-        expect(Payment.last).to have_state(:completed)
-      end
+    before do
+      post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
 
-    context 'when logged in as user' do
-      it 'user is not allowed to visit order page' do
-        post user_session_path, params: { user: { email: user.email, password: user.password } }
-        get '/admin/orders'
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to '/'
-      end
+    it "gets order's page with order's payment status" do
+      get "/admin/orders/#{order.id}"
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(order.payment.aasm_state.to_s)
     end
 
-    context 'without logging in' do
-      it 'visitor is not allowed to visit order page' do
-        get "/admin/orders/#{Order.last.id}"
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to '/'
-      end
+    it "admin can change an order's payment status from 'pending' to 'failed'" do
+      patch "/admin/orders/#{order.id}/payment_status?aasm_state=failed"
+      payment.reload
+      expect(response).to have_http_status(:ok)
+      expect(payment).to have_state(:failed)
+    end
+
+    it "admin can change an order's payment status from 'pending' to 'completed'" do
+      patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
+      payment.reload
+      expect(response).to have_http_status(:ok)
+      expect(payment).to have_state(:completed)
+    end
+  end
+
+  context 'when logged in as user' do
+    it 'is not allowed to visit order page' do
+      post user_session_path, params: { user: { email: user.email, password: user.password } }
+      get '/admin/orders'
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to '/'
+    end
+  end
+
+  context 'when guest visits app' do
+    it 'guest is not allowed to visit order page' do
+      get "/admin/orders/#{order.id}"
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to '/'
     end
   end
 end

--- a/spec/requests/payment_status_request_spec.rb
+++ b/spec/requests/payment_status_request_spec.rb
@@ -14,20 +14,20 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
       post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
 
-    it "gets order's page with order's payment status" do
+    it "is allowed to gets order's page with order's payment status" do
       get "/admin/orders/#{order.id}"
       expect(response).to have_http_status(:ok)
       expect(response.body).to include(order.payment.aasm_state.to_s)
     end
 
-    it "admin can change an order's payment status from 'pending' to 'failed'" do
+    it "is allowed to change an order's payment status from 'pending' to 'failed'" do
       patch "/admin/orders/#{order.id}/payment_status?aasm_state=failed"
       payment.reload
       expect(response).to have_http_status(:ok)
       expect(payment).to have_state(:failed)
     end
 
-    it "admin can change an order's payment status from 'pending' to 'completed'" do
+    it "is allowed to change an order's payment status from 'pending' to 'completed'" do
       patch "/admin/orders/#{order.id}/payment_status?aasm_state=completed"
       payment.reload
       expect(response).to have_http_status(:ok)
@@ -45,7 +45,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
   end
 
   context 'when guest visits app' do
-    it 'guest is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       get "/admin/orders/#{order.id}"
       expect(response).to have_http_status(:found)
       expect(response).to redirect_to '/'

--- a/spec/requests/payment_status_request_spec.rb
+++ b/spec/requests/payment_status_request_spec.rb
@@ -21,15 +21,15 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
       end
 
       it "admin can change an order's payment status from 'pending' to 'failed'" do
-        patch payment_status_admin_order_path(order), params: { payment: { aasm_state: :failed } }
+        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=failed"
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('failed')
+        expect(Payment.last).to have_state(:failed)
       end
 
       it "admin can change an order's payment status from 'pending' to 'completed'" do
-        patch payment_status_admin_order_path(order), params: { payment: { aasm_state: :completed } }
+        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
         expect(response).to have_http_status(:ok)
-        expect(response.body).to include('completed')
+        expect(Payment.last).to have_state(:completed)
       end
     end
 

--- a/spec/requests/shipment_status_request_spec.rb
+++ b/spec/requests/shipment_status_request_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
 
   describe 'when logged in as admin' do
     let(:admin) { create(:admin) }
+
     before do
       post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
@@ -51,7 +52,6 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
         expect(shipment).to have_state(:shipped)
       end
     end
-  
 
     context 'admin is not allowed to' do
       it "change an order's shipment status from 'ready' to 'shipped' if payment status is not 'completed'" do

--- a/spec/requests/shipment_status_request_spec.rb
+++ b/spec/requests/shipment_status_request_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'AdminOrderPaymentStatus', type: :request do
+RSpec.describe 'AdminOrderShipmentStatus', type: :request do
   let(:user) { create(:user) }
   let(:shipment) { create(:shipment) }
   let(:payment) { create(:payment) }
@@ -15,7 +15,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
       post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
 
-    context 'admin is allowed to' do
+    context 'is allowed to' do
       it "gets order's page with order's shipment status" do
         get "/admin/orders/#{order.id}"
         expect(response).to have_http_status(:ok)
@@ -53,7 +53,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
       end
     end
 
-    context 'admin is not allowed to' do
+    context 'is not allowed to' do
       it "change an order's shipment status from 'ready' to 'shipped' if payment status is not 'completed'" do
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=ready"
         patch "/admin/orders/#{order.id}/shipment_status?aasm_state=shipped"
@@ -64,7 +64,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
   end
 
   context 'when logged in as user' do
-    it 'user is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       post user_session_path, params: { user: { email: user.email, password: user.password } }
       get '/admin/orders'
       expect(response).to have_http_status(:found)
@@ -73,7 +73,7 @@ RSpec.describe 'AdminOrderPaymentStatus', type: :request do
   end
 
   context 'when guest visits app' do
-    it 'guest is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       get "/admin/orders/#{order.id}"
       expect(response).to have_http_status(:found)
       expect(response).to redirect_to '/'

--- a/spec/requests/shipment_status_request_spec.rb
+++ b/spec/requests/shipment_status_request_spec.rb
@@ -3,73 +3,73 @@
 require 'rails_helper'
 
 RSpec.describe 'AdminOrderPaymentStatus', type: :request do
-  describe 'GET orders#show' do
-    let(:admin) { create(:admin) }
-    let(:user) { create(:user) }
-    let!(:shipment) { create(:shipment) }
-    let!(:payment) { create(:payment) }
-    let!(:order) { create(:order, user_id: user.id, payment_id: payment.id, shipment_id: shipment.id) }
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+  let(:shipment) { create(:shipment) }
+  let(:payment) { create(:payment) }
+  let!(:order) { create(:order, user_id: user.id, payment_id: payment.id, shipment_id: shipment.id) }
 
-    context 'when logged in as admin' do
-      before do
-        post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
-      end
-
-      it "gets order's page with order's shipment status" do
-        get "/admin/orders/#{Order.last.id}"
-        expect(response).to have_http_status(:ok)
-        expect(shipment).to have_state(:pending)
-      end
-
-      it "admin can change an order's shipment status from 'pending' to 'ready'" do
-        # patch shipment_status_admin_order_path(order), params: { shipment: { aasm_state: :ready } }
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        expect(response).to have_http_status(:ok)
-        expect(Shipment.last).to have_state(:ready)
-      end
-
-      it "admin can change an order's shipment status from 'pending' to 'canceled'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=canceled"
-        expect(response).to have_http_status(:ok)
-        expect(Shipment.last).to have_state(:canceled)
-      end
-
-      it "admin can change an order's shipment status from 'ready' to 'failed'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=failed"
-        expect(response).to have_http_status(:ok)
-        expect(Shipment.last).to have_state(:failed)
-      end
-
-      it "admin cannot change an order's shipment status from 'ready' to 'shipped' if payment status is not 'completed'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=shipped"
-        expect(Shipment.last).not_to allow_event :delivered
-      end
-
-      it "admin can change an order's shipment status from 'ready' to 'shipped' if payment status is 'completed'" do
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
-        patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
-        patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=shipped"
-        expect(Shipment.last).to have_state(:shipped)
-      end
+  describe 'when logged in as admin' do
+    before do
+      post admin_session_path, params: { admin: { email: admin.email, password: admin.password } }
     end
 
-    context 'when logged in as user' do
-      it 'user is not allowed to visit order page' do
-        post user_session_path, params: { user: { email: user.email, password: user.password } }
-        get '/admin/orders'
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to '/'
-      end
+    context 'you are allowed to'
+    it "gets order's page with order's shipment status" do
+      get "/admin/orders/#{Order.last.id}"
+      expect(response).to have_http_status(:ok)
+      expect(shipment).to have_state(:pending)
     end
 
-    context 'without logging in' do
-      it 'visitor is not allowed to visit order page' do
-        get "/admin/orders/#{Order.last.id}"
-        expect(response).to have_http_status(:found)
-        expect(response).to redirect_to '/'
-      end
+    it "admin can change an order's shipment status from 'pending' to 'ready'" do
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+      expect(response).to have_http_status(:ok)
+      expect(Shipment.last).to have_state(:ready)
+    end
+
+    it "admin can change an order's shipment status from 'pending' to 'canceled'" do
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=canceled"
+      expect(response).to have_http_status(:ok)
+      expect(Shipment.last).to have_state(:canceled)
+    end
+
+    it "admin can change an order's shipment status from 'ready' to 'failed'" do
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=failed"
+      expect(response).to have_http_status(:ok)
+      expect(Shipment.last).to have_state(:failed)
+    end
+
+    it "change an order's shipment status from 'ready' to 'shipped' if payment status is 'completed'" do
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+      patch "/admin/orders/#{Order.last.id}/payment_status?aasm_state=completed"
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=shipped"
+      expect(Shipment.last).to have_state(:shipped)
+    end
+  end
+
+  context 'you are not allowed to' do
+    it "admin can't change an order's shipment status from 'ready' to 'shipped' if payment status is not 'completed'" do
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=ready"
+      patch "/admin/orders/#{Order.last.id}/shipment_status?aasm_state=shipped"
+      expect(Shipment.last).not_to allow_event :delivered
+    end
+  end
+
+  context 'when logged in as user' do
+    it 'user is not allowed to visit order page' do
+      post user_session_path, params: { user: { email: user.email, password: user.password } }
+      get '/admin/orders'
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to '/'
+    end
+  end
+
+  context 'without logging in' do
+    it 'visitor is not allowed to visit order page' do
+      get "/admin/orders/#{Order.last.id}"
+      expect(response).to have_http_status(:found)
+      expect(response).to redirect_to '/'
     end
   end
 end

--- a/spec/system/admin_update_product_spec.rb
+++ b/spec/system/admin_update_product_spec.rb
@@ -31,8 +31,7 @@ RSpec.describe 'AdminUpdatingProducts', type: :system do
     fill_in 'product_prize', with: updated_product.prize
     click_button 'Update Product'
     expect(page).to have_content('Product has been successfully updated.')
-    expect(page).to have_content(updated_product.prize)
-    expect(page).to have_no_content(product.prize)
+    expect(page).to have_no_field('product_prize', with: product.prize)
   end
 
   it 'prevents admin to update product without name' do

--- a/spec/system/order_status_spec.rb
+++ b/spec/system/order_status_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ShipmentStatus', type: :system do
+RSpec.describe 'OrderStatus', type: :system do
   let(:admin) { create(:admin) }
   let(:user) { create(:user) }
   let(:shipment) { create(:shipment) }
@@ -20,38 +20,37 @@ RSpec.describe 'ShipmentStatus', type: :system do
     end
 
     context 'you have permission to' do
-      it 'see pending shipment status on order page' do
-        expect(page).to have_content('Shipment status: pending')
+      it 'see new order status on order page' do
+        expect(page).to have_content('Order Status: new')
       end
 
-      it "change an order's shipment status from 'pending' to 'canceled'" do
-        find('#shipment').click_link('canceled')
-        expect(page).to have_content('Shipment status: canceled')
-      end
-
-      it "change an order's shipment status from 'pending' to 'ready'" do
-        find('#shipment').click_link('ready')
-        expect(page).to have_content('Shipment status: ready')
-      end
-
-      it "change an order's shipment status from 'ready' to 'failed'" do
-        find('#shipment').click_link('ready')
-        find('#shipment').click_link('failed')
-        expect(page).to have_content('Shipment status: failed')
+      it "change an order status from 'new' to 'failed'" do
+        find('#order').click_link('failed')
+        expect(page).to have_content('Order Status: failed')
       end
     end
 
-    it "change an order's shipment status from 'ready' to 'shipped' if payment status is 'completed'" do
-      find('#payment').click_link('completed')
-      find('#shipment').click_link('ready')
-      find('#shipment').click_link('shipped')
-      expect(page).to have_content('Shipment status: shipped')
+    context "you have permission to change order status to 'completed' only if" do
+      it "shipment status is 'shipped' and payment status is 'completed'" do
+        find('#payment').click_link('completed')
+        find('#shipment').click_link('ready')
+        find('#shipment').click_link('shipped')
+        find('#order').click_link('completed')
+        expect(page).to have_content('Order Status: completed')
+      end
     end
 
-    context "you don't have permission to" do
-      it "change an order's shipment status from 'ready' to 'shipped' if payment status is not 'completed'" do
+    context "you don't have permission to change order status to 'completed' if" do
+      it "shipment status isn't 'shipped' and payment status isn't 'completed'" do
         find('#shipment').click_link('ready')
-        expect(page).not_to have_content('shipped')
+        expect(page).to have_content('Payment status: pending')
+        expect(page).to have_no_css('#order', text: 'completed')
+      end
+
+      it "shipment status isn't 'shipped' and payment status is 'completed'" do
+        find('#shipment').click_link('ready')
+        find('#payment').click_link('completed')
+        expect(page).to have_no_css('#order', text: 'completed')
       end
     end
   end

--- a/spec/system/order_status_spec.rb
+++ b/spec/system/order_status_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'OrderStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    context 'you have permission to' do
+    context 'is allowed to' do
       it 'see new order status on order page' do
         expect(order).to have_state(:new)
       end
@@ -33,7 +33,7 @@ RSpec.describe 'OrderStatus', type: :system do
     end
 
     context "when shipment status is 'shipped' and payment status is 'completed'" do
-      it "admin is allowed to change order status to 'completed'" do
+      it "is allowed to change order status to 'completed'" do
         find('#payment').click_link('completed')
         find('#shipment').click_link('ready')
         find('#shipment').click_link('shipped')
@@ -44,7 +44,7 @@ RSpec.describe 'OrderStatus', type: :system do
     end
 
     context "when shipment status isn't 'shipped' and payment status isn't 'completed'" do
-      it "admin is not allowed to change order status to 'completed'" do
+      it "is not allowed to change order status to 'completed'" do
         find('#shipment').click_link('ready')
         shipment.reload
         expect(order).not_to allow_event :done
@@ -52,7 +52,7 @@ RSpec.describe 'OrderStatus', type: :system do
     end
 
     context "when shipment status isn't 'shipped' and payment status is 'completed'" do
-      it "admin is not allowed to change order status to 'completed'" do
+      it "is not allowed to change order status to 'completed'" do
         find('#shipment').click_link('ready')
         find('#payment').click_link('completed')
         shipment.reload
@@ -72,7 +72,7 @@ RSpec.describe 'OrderStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'user cannot visit order page' do
+    it 'is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end
@@ -83,7 +83,7 @@ RSpec.describe 'OrderStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'guest is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end

--- a/spec/system/order_status_spec.rb
+++ b/spec/system/order_status_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'OrderStatus', type: :system do
 
   describe 'when logged in as admin' do
     let(:admin) { create(:admin) }
+
     before do
       driven_by(:rack_test)
       visit new_admin_session_path
@@ -30,7 +31,7 @@ RSpec.describe 'OrderStatus', type: :system do
         expect(order).to have_state(:failed)
       end
     end
-  
+
     context "when shipment status is 'shipped' and payment status is 'completed'" do
       it "admin is allowed to change order status to 'completed'" do
         find('#payment').click_link('completed')
@@ -41,12 +42,12 @@ RSpec.describe 'OrderStatus', type: :system do
         expect(order).to have_state(:completed)
       end
     end
-  
+
     context "when shipment status isn't 'shipped' and payment status isn't 'completed'" do
       it "admin is not allowed to change order status to 'completed'" do
         find('#shipment').click_link('ready')
         shipment.reload
-        expect(order).to_not allow_event :done
+        expect(order).not_to allow_event :done
       end
     end
 
@@ -56,7 +57,7 @@ RSpec.describe 'OrderStatus', type: :system do
         find('#payment').click_link('completed')
         shipment.reload
         payment.reload
-        expect(order).to_not allow_event :done
+        expect(order).not_to allow_event :done
       end
     end
   end

--- a/spec/system/payment_status_spec.rb
+++ b/spec/system/payment_status_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'PaymentStatus', type: :system do
-  let(:admin) { create(:admin) }
   let(:user) { create(:user) }
   let(:payment) { create(:payment) }
-  let(:order) { create(:order, user_id: user.id, payment_id: payment.id) }
+  let(:order) { create(:order, user: user, payment: payment) }
 
   context 'when logged in as admin' do
+    let(:admin) { create(:admin) }
     before do
       driven_by(:rack_test)
       visit new_admin_session_path
@@ -19,17 +19,19 @@ RSpec.describe 'PaymentStatus', type: :system do
     end
 
     it 'admin sees pending payment status on order page' do
-      expect(page).to have_content('pending')
+      expect(payment).to have_state(:pending)
     end
 
     it "admin can change an order's payment status from 'pending' to 'failed'" do
       find('#payment').click_link('failed')
-      expect(page).to have_content('Payment status: failed')
+      payment.reload
+      expect(payment).to have_state(:failed)
     end
 
     it "admin can change an order's payment status from 'pending' to 'completed'" do
       find('#payment').click_link('completed')
-      expect(page).to have_content('Payment status: completed')
+      payment.reload
+      expect(payment).to have_state(:completed)
     end
   end
 
@@ -44,6 +46,17 @@ RSpec.describe 'PaymentStatus', type: :system do
     end
 
     it 'user cannot visit order page' do
+      expect(page).to have_content('You are not authorized')
+    end
+  end
+
+  context 'when guest visits app' do
+    before do
+      driven_by(:rack_test)
+      visit admin_order_path(order)
+    end
+
+    it 'guest is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end

--- a/spec/system/payment_status_spec.rb
+++ b/spec/system/payment_status_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe 'PaymentStatus', type: :system do
 
   context 'when logged in as admin' do
     let(:admin) { create(:admin) }
+
     before do
       driven_by(:rack_test)
       visit new_admin_session_path

--- a/spec/system/payment_status_spec.rb
+++ b/spec/system/payment_status_spec.rb
@@ -19,17 +19,17 @@ RSpec.describe 'PaymentStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'admin sees pending payment status on order page' do
+    it 'is allowed to see pending payment status on order page' do
       expect(payment).to have_state(:pending)
     end
 
-    it "admin can change an order's payment status from 'pending' to 'failed'" do
+    it "is allowed to change an order's payment status from 'pending' to 'failed'" do
       find('#payment').click_link('failed')
       payment.reload
       expect(payment).to have_state(:failed)
     end
 
-    it "admin can change an order's payment status from 'pending' to 'completed'" do
+    it "is allowed to change an order's payment status from 'pending' to 'completed'" do
       find('#payment').click_link('completed')
       payment.reload
       expect(payment).to have_state(:completed)
@@ -46,7 +46,7 @@ RSpec.describe 'PaymentStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'user cannot visit order page' do
+    it 'is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end
@@ -57,7 +57,7 @@ RSpec.describe 'PaymentStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'guest is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end

--- a/spec/system/payment_status_spec.rb
+++ b/spec/system/payment_status_spec.rb
@@ -3,10 +3,10 @@
 require 'rails_helper'
 
 RSpec.describe 'PaymentStatus', type: :system do
-  let!(:admin) { create(:admin) }
-  let!(:user) { create(:user) }
-  let!(:payment) { create(:payment) }
-  let!(:order) { create(:order, user_id: user.id, payment_id: payment.id) }
+  let(:admin) { create(:admin) }
+  let(:user) { create(:user) }
+  let(:payment) { create(:payment) }
+  let(:order) { create(:order, user_id: user.id, payment_id: payment.id) }
 
   context 'when logged in as admin' do
     before do

--- a/spec/system/shipment_status_spec.rb
+++ b/spec/system/shipment_status_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'ShipmentStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    context 'you have permission to' do
+    context 'it is allowed to' do
       it 'see pending shipment status on order page' do
         expect(shipment).to have_state(:pending)
       end
@@ -54,7 +54,7 @@ RSpec.describe 'ShipmentStatus', type: :system do
       end
     end
 
-    context "you don't have permission to" do
+    context 'it is not allowed to' do
       it "change an order's shipment status from 'ready' to 'shipped' if payment status is not 'completed'" do
         find('#shipment').click_link('ready')
         shipment.reload
@@ -73,7 +73,7 @@ RSpec.describe 'ShipmentStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'user cannot visit order page' do
+    it 'is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end
@@ -84,7 +84,7 @@ RSpec.describe 'ShipmentStatus', type: :system do
       visit admin_order_path(order)
     end
 
-    it 'guest is not allowed to visit order page' do
+    it 'is not allowed to visit order page' do
       expect(page).to have_content('You are not authorized')
     end
   end

--- a/spec/system/shipment_status_spec.rb
+++ b/spec/system/shipment_status_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.describe 'ShipmentStatus', type: :system do 
+RSpec.describe 'ShipmentStatus', type: :system do
   let(:user) { create(:user) }
   let(:shipment) { create(:shipment) }
   let(:payment) { create(:payment) }
@@ -10,6 +10,7 @@ RSpec.describe 'ShipmentStatus', type: :system do
 
   describe 'when logged in as admin' do
     let(:admin) { create(:admin) }
+
     before do
       driven_by(:rack_test)
       visit new_admin_session_path
@@ -42,7 +43,7 @@ RSpec.describe 'ShipmentStatus', type: :system do
         shipment.reload
         expect(shipment).to have_state(:failed)
       end
-    
+
       it "change an order's shipment status from 'ready' to 'shipped' if payment status is 'completed'" do
         find('#payment').click_link('completed')
         find('#shipment').click_link('ready')


### PR DESCRIPTION
**Change order's status**

Opis:
As an admin, I want to be able to update the order's status so I can mark it as completed or failed

Acceptance criteria:
- An admin can change an order's status using a button on the order's page
- New order's status can be changed to "completed" if its shipment status is "shipped" and its payment status is "completed"
- Order's status can be changed to "failed"
- There is a system & request spec